### PR TITLE
Change array to  list

### DIFF
--- a/src/RedHat.AspNetCore.Server.Kestrel.Transport.Linux/AcceptThread.cs
+++ b/src/RedHat.AspNetCore.Server.Kestrel.Transport.Linux/AcceptThread.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Threading;
 
@@ -143,7 +144,7 @@ namespace RedHat.AspNetCore.Server.Kestrel.Transport.Linux
                                 if (*key == acceptKey)
                                 {
                                     var handler = handlers[nextHandler];
-                                    nextHandler = (nextHandler + 1) % handlers.Length;
+                                    nextHandler = (nextHandler + 1) % handlers.Count;
                                     socket.TryAcceptAndSendHandleTo(handler);
                                 }
                                 else


### PR DESCRIPTION
Change `int[] _handlers ` to `List<int> _handlers` to avoid many `Array.Copy`. List makes a Array.Copy, but it's not all the time, List begin with array of 4 position and will double length of array every time array is full 